### PR TITLE
proc: add method to bulk-convert file+lines to map[line]pcs

### DIFF
--- a/pkg/proc/bininfo.go
+++ b/pkg/proc/bininfo.go
@@ -406,6 +406,21 @@ func (bi *BinaryInfo) AllPCsForFileLine(filename string, lineno int) []uint64 {
 	return r
 }
 
+// AllPCsForFileLines returns a map providing all PC addresses for filename and each line in linenos
+func (bi *BinaryInfo) AllPCsForFileLines(filename string, linenos []int) map[int][]uint64 {
+	r := make(map[int][]uint64)
+	for _, line := range linenos {
+		r[line] = make([]uint64, 0, 1)
+	}
+	for _, cu := range bi.compileUnits {
+		if cu.lineInfo.Lookup[filename] != nil {
+			// r = append(r, cu.lineInfo.AllPCsForFileLine(filename, lineno)...)
+			cu.lineInfo.AllPCsForFileLines(filename, r)
+		}
+	}
+	return r
+}
+
 // PCToFunc returns the function containing the given PC address
 func (bi *BinaryInfo) PCToFunc(pc uint64) *Function {
 	i := sort.Search(len(bi.Functions), func(i int) bool {


### PR DESCRIPTION
This is an algorithmic assist to an automated DWARF Quality Checker that makes running it on large binaries plausibly fast.  If you could upstream it into your repo, that would be helpful.

DWARF Quality Checker lives here: https://github.com/dr2chase/dwarf-goodness
It needs more work, but the goal is to turn it both into a regression test for DWARF quality and a tool to help us figure out what needs work.